### PR TITLE
Fix automation describeCondition for number state type

### DIFF
--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -901,7 +901,7 @@ const tryDescribeCondition = (
         )
       : undefined;
 
-    if (condition.above && condition.below) {
+    if (condition.above !== undefined && condition.below !== undefined) {
       return hass.localize(
         `${conditionsTranslationBaseKey}.numeric_state.description.above-below`,
         {
@@ -912,7 +912,7 @@ const tryDescribeCondition = (
         }
       );
     }
-    if (condition.above) {
+    if (condition.above !== undefined) {
       return hass.localize(
         `${conditionsTranslationBaseKey}.numeric_state.description.above`,
         {
@@ -922,7 +922,7 @@ const tryDescribeCondition = (
         }
       );
     }
-    if (condition.below) {
+    if (condition.below !== undefined) {
       return hass.localize(
         `${conditionsTranslationBaseKey}.numeric_state.description.below`,
         {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When using a number state condition in an automation, the UI used an incorrect evaluation when trying to describe the condition which made the label default to the default value:
<img width="811" alt="Screenshot 2024-06-10 at 11 43 55" src="https://github.com/koostamas/frontend/assets/6962207/bce1439f-03f9-45f7-9f58-1c97a23f0eb6">
To fix this, I just changed the evaluation to check directly for `undefined` value.
<img width="810" alt="Screenshot 2024-06-10 at 11 44 26" src="https://github.com/koostamas/frontend/assets/6962207/2d3a689b-8919-40e1-9121-79917a17db95">
(The red rectangles are just for directing attention, edited on the screenshot, not in the code (obviously)).

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
